### PR TITLE
SAAS-61: allow to pass jcustomer as a zip file to the build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,21 @@ ENV JCUSTOMER_HOME=/opt/jcustomer
 
 RUN useradd karaf -u 1000 -U -m -d /home/karaf
 
+# these two files need to be copied on the same line since we want to copy installer.jar IF it exists, and copy doesn't support conditional copy (only copy if file exists)
+COPY entrypoint.sh jcustomer.zip* /opt/
+
+
 RUN cd /opt \
-    && wget -nv -O jcustomer.tar.gz $RELEASE_URL \
-    && tar xzvf jcustomer.tar.gz \
-    && rm jcustomer.tar.gz \
+    && if [ ! -f "jcustomer.zip" ]; then \
+        wget -nv -O jcustomer.tar.gz $RELEASE_URL; \
+        tar xzvf jcustomer.tar.gz; \
+        rm jcustomer.tar.gz; \
+       fi \
+    && if [ -f "jcustomer.zip" ]; then \
+        unzip jcustomer.zip ;\
+        rm jcustomer.zip; \
+       fi \
+    && rm entrypoint.sh \
     && ln -s $(ls -1) jcustomer \
     && wget -nv -O  $JCUSTOMER_HOME/etc/allCountries.zip http://download.geonames.org/export/dump/allCountries.zip \
     && chown -R karaf: /opt/*

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Env vars:
 * `MAXMIND_KEY` : The MAXMIND API key to fetch GeoLite DB (see https://dev.maxmind.com/geoip/geoip2/geolite2/). If not provided, the db won't be fetch.
 * `unomi_env_var_*` : All unomi parameters that can be configured with env var can be defined with this prefix. If you want to specify multiple variables, an env file is strongly recomended instead of providing all of them one by one with -e docker option. The env var unomi_env_var_MY_UNOMI_PARAMATER will be converted to MY_UNOMI_PARAMATER and added to unomi process env vars. As the image doesn't embed any elasticsearch, the only required parameters are unomi_env_var_UNOMI_ELASTICSEARCH_ADDRESSES and unomi_env_var_UNOMI_ELASTICSEARCH_CLUSTERNAME
 
+### Build
+
+The jCustomer archive can come from two locations:
+ - a RELEASE_URL argument which points to a .tar.gz file
+ - a jcustomer.zip file on the same directory as the Dockerfile
+
 ### Examples
 #### basic run
 ```bash


### PR DESCRIPTION
Allows to pass jCustomer as a zip file, and not necessarily as a URL (that can be protected by credentials)